### PR TITLE
iterative-telemetry 0.0.9 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip
     - setuptools_scm >=6.3.1
     - wheel
+    - setuptools
   run:
     - python
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,18 @@ source:
   sha256: 53686c3e912a33e8bf6975b878fd4bd0a7d589c8bad0a6a5573714af9e731dc2
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - setuptools_scm >=6.3.1
+    - wheel
   run:
-    - python >=3.7
+    - python
     - requests
     - appdirs
     - filelock
@@ -37,8 +38,13 @@ test:
 about:
   home: https://github.com/iterative/telemetry-python
   summary: Common library to send usage telemetry
+  description: |
+    Common library to send usage telemetry,
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  doc_url: https://github.com/iterative/telemetry-python/blob/main/README.rst
+  dev_url: https://github.com/iterative/telemetry-python
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,17 @@ requirements:
     - distro
 
 test:
+  source_files:
+    - tests
   imports:
     - iterative_telemetry
   requires:
     - pip
+    - pytest
+    - pytest-mock
   commands:
     - pip check
+    - pytest -vv tests
 
 about:
   home: https://github.com/iterative/telemetry-python


### PR DESCRIPTION
iterative-telemetry 0.0.9 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5393]
- dev_url:        https://github.com/iterative/telemetry-python/tree/0.0.9
- conda_forge:    https://github.com/conda-forge/iterative-telemetry-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/iterative-telemetry/0.0.9
- pypi inspector: https://inspector.pypi.io/project/iterative-telemetry/0.0.9

### Explanation of changes:

- feedstock added to aggregate
- tests require `mocker` which we don't have


[PKG-5393]: https://anaconda.atlassian.net/browse/PKG-5393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ