### PR TITLE
iterative-telemetry 0.0.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,1 @@
-upload_channels:
-  - sfe1ed40
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "iterative-telemetry" %}
-{% set version = "0.0.9" %}
+{% set version = "0.0.10" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 53686c3e912a33e8bf6975b878fd4bd0a7d589c8bad0a6a5573714af9e731dc2
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 7fde6111de6fa4acf5a95a6190cc9cc5d17d835a815f0a18ece201f6031f4ed6
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - python
     - pip
     - setuptools_scm >=6.3.1
-    - wheel
     - setuptools
   run:
     - python


### PR DESCRIPTION
## iterative-telemetry 0.0.10

**Destination channel:** defaults

### Links

- [PKG-13099](https://anaconda.atlassian.net/browse/PKG-13099)
- [PyPI](https://pypi.org/project/iterative-telemetry/0.0.10/)
- [Upstream repository](https://github.com/iterative/telemetry-python)

### Explanation of changes:

- Updated iterative-telemetry from 0.0.9 to 0.0.10
- Source URL fixed from pypi.io to pypi.org
- Removed unnecessary wheel from host deps
- No dependency changes (requests, appdirs, filelock, distro)

[PKG-13099]: https://anaconda.atlassian.net/browse/PKG-13099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ